### PR TITLE
make entities serializable

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   summary: 'Domain Driven Design patterns for Space applications.',
   name: 'space:domain',
   version: '0.1.0',
-  git: 'https://github.com/meteor-space/domain.git',
+  git: 'https://github.com/meteor-space/domain.git'
 });
 
 Package.onUse(function(api) {
@@ -10,6 +10,8 @@ Package.onUse(function(api) {
   api.versionsFrom("METEOR@1.0");
 
   api.use([
+    'check',
+    'ecmascript',
     'space:base@3.2.1',
     'space:messaging@2.1.0'
   ]);
@@ -17,12 +19,12 @@ Package.onUse(function(api) {
   // SHARED
   api.addFiles([
     'source/namespace.js',
-    'source/value-object.js',
+    'source/value-object.js'
   ]);
 
   // SERVER ONLY
   api.addFiles([
-    'source/entity.js',
+    'source/entity.js'
   ], 'server');
 
 });
@@ -33,15 +35,15 @@ Package.onTest(function(api) {
     'check',
     'space:testing@2.0.0',
     'space:domain',
-    'practicalmeteor:munit@2.1.5',
+    'practicalmeteor:munit@2.1.5'
   ]);
 
   api.addFiles([
-    'tests/value-object.tests.js',
+    'tests/value-object.tests.js'
   ]);
 
   api.addFiles([
-    'tests/entity.tests.js',
+    'tests/entity.tests.js'
   ], 'server');
 
 });

--- a/package.js
+++ b/package.js
@@ -11,6 +11,7 @@ Package.onUse(function(api) {
 
   api.use([
     'check',
+    'underscore',
     'ecmascript',
     'space:base@3.2.1',
     'space:messaging@2.1.0'

--- a/package.js
+++ b/package.js
@@ -34,6 +34,7 @@ Package.onTest(function(api) {
 
   api.use([
     'check',
+    'ecmascript',
     'space:testing@2.0.0',
     'space:domain',
     'practicalmeteor:munit@2.1.5'

--- a/source/entity.js
+++ b/source/entity.js
@@ -10,10 +10,10 @@ Space.messaging.Serializable.extend(Space.domain, 'Entity', {
 
   Constructor(data) {
     let preparedData = data;
-    if (data instanceof Guid) {
+    if (_.isString(data) || data instanceof Guid) {
       preparedData = { id: data };
     }
-    if (!preparedData.id) throw new Error(this.ERRORS.idRequired());
+    if (!preparedData || !preparedData.id) throw new Error(this.ERRORS.idRequired());
     Space.messaging.Serializable.call(this, preparedData);
   },
 

--- a/source/entity.js
+++ b/source/entity.js
@@ -1,24 +1,34 @@
-Space.Object.extend(Space.domain, 'Entity', {
+Space.messaging.Serializable.extend(Space.domain, 'Entity', {
 
   ERRORS: {
-    idRequired: function() {
+    idRequired() {
       return 'Entities need an ID on creation.';
     }
   },
 
-  _id: null,
+  id: null,
 
-  Constructor: function(id) {
-    if(!id) throw new Error(this.ERRORS.idRequired());
-    this._id = id;
+  Constructor(data) {
+    let preparedData = data;
+    if (data instanceof Guid) {
+      preparedData = { id: data };
+    }
+    if (!preparedData.id) throw new Error(this.ERRORS.idRequired());
+    Space.messaging.Serializable.call(this, preparedData);
   },
 
-  getId: function() {
-    return this._id;
+  fields() {
+    return {
+      id: Match.OneOf(String, Guid)
+    };
   },
 
-  isEqual: function(other) {
-    return (other.constructor === this.constructor) && other.getId() === this._id;
+  getId() {
+    return this.id;
+  },
+
+  equals(other) {
+    return (other.constructor === this.constructor) && other.getId() === this.id;
   }
 
 });

--- a/source/value-object.js
+++ b/source/value-object.js
@@ -5,13 +5,12 @@ Space.messaging.Serializable.extend(Space.domain, 'ValueObject', {
   },
 
   _hasSameValues: function(other) {
-    var hasSameValues = true;
-    for(var key in this.fields()) {
-      if(this[key] instanceof Space.domain.ValueObject) {
-        if(!this[key].equals(other[key])) hasSameValues = false;
-      }
-      else {
-        if(this[key] !== other[key]) hasSameValues = false;
+    let hasSameValues = true;
+    for (let key in this.fields()) {
+      if (this[key] instanceof Space.domain.ValueObject) {
+        if (!this[key].equals(other[key])) hasSameValues = false;
+      } else {
+        if (this[key] !== other[key]) hasSameValues = false;
       }
     }
     return hasSameValues;

--- a/tests/entity.tests.js
+++ b/tests/entity.tests.js
@@ -17,12 +17,12 @@ describe("Space.domain.Entity", function () {
 
     it("is equal when same class and ID", function () {
       var first = new Entity('123'), second = new Entity('123');
-      expect(first.isEqual(second)).to.be.true;
+      expect(first.equals(second)).to.be.true;
     });
 
     it("is not equal when same class but different ID", function () {
       var first = new Entity('123'), second = new Entity('543');
-      expect(first.isEqual(second)).to.be.false;
+      expect(first.equals(second)).to.be.false;
     });
 
     it("is not equal when different class but same ID", function () {
@@ -30,7 +30,7 @@ describe("Space.domain.Entity", function () {
           first = new Entity('123'),
           second = new OtherEntity('123');
 
-      expect(first.isEqual(second)).to.be.false;
+      expect(first.equals(second)).to.be.false;
     });
 
   });

--- a/tests/entity.tests.js
+++ b/tests/entity.tests.js
@@ -1,34 +1,37 @@
-describe("Space.domain.Entity", function () {
+describe("Space.domain.Entity", function() {
 
-  var Entity = Space.domain.Entity;
+  let Entity = Space.domain.Entity;
 
-  it("requires an ID on construction", function () {
-    function createEntityWithoutId() { new Entity(); }
+  it("requires an ID on construction", function() {
+    let createEntityWithoutId = function() { return new Entity(); };
     expectedError = Space.domain.Entity.prototype.ERRORS.idRequired();
     expect(createEntityWithoutId).to.throw(expectedError);
   });
 
-  it("provides an accessor for its ID", function () {
-    var id = '123', entity = new Entity(id);
+  it("provides an accessor for its ID", function() {
+    let id = '123';
+    let entity = new Entity(id);
     expect(entity.getId()).to.equal(id);
   });
 
-  describe("comparing entities", function () {
+  describe("comparing entities", function() {
 
-    it("is equal when same class and ID", function () {
-      var first = new Entity('123'), second = new Entity('123');
+    it("is equal when same class and ID", function() {
+      let first = new Entity('123');
+      let second = new Entity('123');
       expect(first.equals(second)).to.be.true;
     });
 
-    it("is not equal when same class but different ID", function () {
-      var first = new Entity('123'), second = new Entity('543');
+    it("is not equal when same class but different ID", function() {
+      let first = new Entity('123');
+      let second = new Entity('543');
       expect(first.equals(second)).to.be.false;
     });
 
-    it("is not equal when different class but same ID", function () {
-      var OtherEntity = Space.domain.Entity.extend('OtherEntity'),
-          first = new Entity('123'),
-          second = new OtherEntity('123');
+    it("is not equal when different class but same ID", function() {
+      let OtherEntity = Space.domain.Entity.extend('OtherEntity');
+      let first = new Entity('123');
+      let second = new OtherEntity('123');
 
       expect(first.equals(second)).to.be.false;
     });

--- a/tests/value-object.tests.js
+++ b/tests/value-object.tests.js
@@ -1,52 +1,54 @@
-describe("Space.domain.ValueObject", function () {
+describe("Space.domain.ValueObject", function() {
 
-  it("extends Space.messaging.Serializable", function () {
+  it("extends Space.messaging.Serializable", function() {
     expect(Space.domain.ValueObject).to.extend(Space.messaging.Serializable);
   });
 
-  describe("comparing value objects", function () {
+  describe("comparing value objects", function() {
 
-    var MyPerson = Space.domain.ValueObject.extend('MyPerson', {
+    let MyPerson = Space.domain.ValueObject.extend('MyPerson', {
       fields: function() {
         return { name: String, age: Match.Integer };
       }
     });
 
-    var MyValue = Space.domain.ValueObject.extend('MyValue', {
+    let MyValue = Space.domain.ValueObject.extend('MyValue', {
       fields: function() {
         return { value: MyPerson };
       }
     });
 
-    it("is equal when all fields are equal", function () {
-      var values = { name: 'Test', age: 1 },
-          first = new MyPerson(values), second = new MyPerson(values);
+    it("is equal when all fields are equal", function() {
+      let values = { name: 'Test', age: 1 };
+      let first = new MyPerson(values);
+      let second = new MyPerson(values);
       expect(first.equals(second)).to.be.true;
     });
 
-    it("is not equal if at least one field is different", function () {
-      var firstValues = { name: 'Test', age: 1 },
-          secondValues = { name: 'Change', age: 1 },
-          first = new MyPerson(firstValues), second = new MyPerson(secondValues);
+    it("is not equal if at least one field is different", function() {
+      let firstValues = { name: 'Test', age: 1 };
+      let secondValues = { name: 'Change', age: 1 };
+      let first = new MyPerson(firstValues);
+      let second = new MyPerson(secondValues);
       expect(first.equals(second)).to.be.false;
     });
 
-    it("supports comparison of nested value objects", function () {
-      var personValues = { name: 'Test', age: 1 },
-          firstPerson = new MyPerson(personValues),
-          secondPerson = new MyPerson(personValues),
-          firstValue = new MyValue({ value: firstPerson }),
-          secondValue = new MyValue({ value: secondPerson });
+    it("supports comparison of nested value objects", function() {
+      let personValues = { name: 'Test', age: 1 };
+      let firstPerson = new MyPerson(personValues);
+      let secondPerson = new MyPerson(personValues);
+      let firstValue = new MyValue({ value: firstPerson });
+      let secondValue = new MyValue({ value: secondPerson });
       expect(firstValue.equals(secondValue)).to.be.true;
     });
 
-    it("is not equal if a sub value object comparison fails", function () {
-      var firstValues = { name: 'Test', age: 1 },
-          secondValues = { name: 'Changed', age: 1 },
-          firstPerson = new MyPerson(firstValues),
-          secondPerson = new MyPerson(secondValues),
-          firstValue = new MyValue({ value: firstPerson }),
-          secondValue = new MyValue({ value: secondPerson });
+    it("is not equal if a sub value object comparison fails", function() {
+      let firstValues = { name: 'Test', age: 1 };
+      let secondValues = { name: 'Changed', age: 1 };
+      let firstPerson = new MyPerson(firstValues);
+      let secondPerson = new MyPerson(secondValues);
+      let firstValue = new MyValue({ value: firstPerson });
+      let secondValue = new MyValue({ value: secondPerson });
       expect(firstValue.equals(secondValue)).to.be.false;
     });
 


### PR DESCRIPTION
This PR makes `Space.domain.Entity` serializable so that they can be "embedded" into aggregates and work smoothly with snapshotting.
