### PR TITLE
adds domain exception event

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,14 +1,14 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "version": "9ffa935061ed85e9958a1810f77f57932a0cb60a"
+    "branch": "develop"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",
-    "version": "0b10fca45edf6e1d630ba32defa502e28cb9f53b"
+    "branch": "feature/serializable-space-errors"
   },
   "space:testing": {
     "git":"https://github.com/meteor-space/testing.git",
-    "version": "0fa24e0db6fdf26443ec7919d379d0d04166c49c"
+    "branch": "develop"
   }
 }

--- a/package.js
+++ b/package.js
@@ -25,7 +25,8 @@ Package.onUse(function(api) {
 
   // SERVER ONLY
   api.addFiles([
-    'source/entity.js'
+    'source/entity.js',
+    'source/server/exception.js'
   ], 'server');
 
 });
@@ -35,6 +36,7 @@ Package.onTest(function(api) {
   api.use([
     'check',
     'ecmascript',
+    'ejson',
     'space:testing@2.0.0',
     'space:domain',
     'practicalmeteor:munit@2.1.5'
@@ -45,7 +47,8 @@ Package.onTest(function(api) {
   ]);
 
   api.addFiles([
-    'tests/entity.tests.js'
+    'tests/entity.tests.js',
+    'tests/exception.tests.js'
   ], 'server');
 
 });

--- a/source/server/exception.js
+++ b/source/server/exception.js
@@ -1,0 +1,14 @@
+Space.messaging.Event.extend(Space.domain, 'Exception', {
+
+  onExtending() {
+    this.type('Space.domain.Exception');
+  },
+
+  fields() {
+    return _.extend(Space.messaging.Event.prototype.fields.call(this), {
+      thrower: String, // Path to aggregate or process that threw the error
+      error: Space.Error
+    });
+  }
+
+});

--- a/tests/exception.tests.js
+++ b/tests/exception.tests.js
@@ -1,0 +1,35 @@
+describe("Space.domain - Exception", function() {
+
+  beforeEach(function() {
+    this.error = new Space.Error('test');
+    this.myExceptionEvent = new Space.domain.Exception({
+      thrower: 'My.awesome.Class',
+      error: this.error
+    });
+  });
+
+  it("is an event", function() {
+    expect(Space.domain.Exception).to.extend(Space.messaging.Event);
+  });
+
+  it("adds required fields to the standard event fields", function() {
+    expect(this.myExceptionEvent.fields()).to.eql({
+      sourceId: Match.Optional(Match.OneOf(String, Guid)),
+      eventVersion: Match.Optional(Match.Integer),
+      version: Match.Optional(Match.Integer),
+      timestamp: Date,
+      meta: Match.Optional(Object),
+      thrower: String,
+      error: Space.Error
+    });
+  });
+
+  it("can be serialized correctly", function() {
+    let copy = EJSON.parse(EJSON.stringify(this.myExceptionEvent));
+    expect(copy).to.be.instanceof(Space.domain.Exception);
+    expect(copy.thrower).to.equal(this.myExceptionEvent.thrower);
+    expect(copy.error).to.be.instanceof(Space.Error);
+    expect(copy.error.message).to.equal(this.error.message);
+  });
+
+});


### PR DESCRIPTION
This PR adds a general purpose `Space.domain.Exception` event class that will be used by the `Space.eventSourcing.Router` to turn domain errors in aggregates / processes into consumable events.
