### PR TITLE
make Event class available on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@ Changelog
 
 ### Next
 #### New Features
-- `Space.domain.ValueObject` and `Space.domain.Entity` are now also Versionable, 
-just like `Space.domain.Event` or `Space.domain.Exception`. 
+- `Space.domain.ValueObject` and `Space.domain.Entity` are now also Versionable,
+just like `Space.domain.Event` or `Space.domain.Exception`.
 Now all domain.Objects intended to be serialized and persisted can be versioned
  to allow on the fly transformations as defined in the object.
+- The `Space.domain.Event` class is not also available on client-side.
 
 ####Breaking change
-- `eventVersion` -> `schemaVersion` in `Space.domain.Event` and 
-`Space.domain.Exception`. Inherited from `Space.messaging.Event`, via mixin 
+- `eventVersion` -> `schemaVersion` in `Space.domain.Event` and
+`Space.domain.Exception`. Inherited from `Space.messaging.Event`, via mixin
 `Space.messaging.Versionable`.
 
 #### Updated dependencies

--- a/package.js
+++ b/package.js
@@ -21,13 +21,13 @@ Package.onUse(function(api) {
   api.addFiles([
     'source/namespace.js',
     'source/value-object.js',
-    'source/command.js'
+    'source/command.js',
+    'source/server/event.js'
   ]);
 
   // SERVER ONLY
   api.addFiles([
     'source/server/entity.js',
-    'source/server/event.js',
     'source/server/exception.js'
   ], 'server');
 


### PR DESCRIPTION
For Meteor 1.3 tests we need to have the event classes available on the client-side (only for testing).
This is because if there is an error thrown that includes a domain event, we get a silent fail in the testing browser window which just logs something about DDP not knowing the EJSON type bla.

This might not be necessary at some point, but i think it's also not a big issues to make the event class available to both environments.
